### PR TITLE
Spike version 1.0

### DIFF
--- a/SimplestTreeParser/pom.xml
+++ b/SimplestTreeParser/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/AfterHead.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/AfterHead.java
@@ -7,10 +7,11 @@ import com.html5parser.SimplestTreeParser.InsertionMode;
 import com.html5parser.SimplestTreeParser.Parser;
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class AfterHead {
 
-	public void process(Document doc, Token token) {
+	public void process(Document doc, Token token, TreeConstructor treeConstructor ) {
 		switch (token.getType()) {
 		case character:
 			break;
@@ -27,15 +28,16 @@ public class AfterHead {
 			break;
 		case end_of_file:
 		default:
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token,  treeConstructor );
 			break;
 		}
 	}
 
-	public void TokenAnythingElse(Document doc) {
+	public void TokenAnythingElse(Document doc,Token token, TreeConstructor treeConstructor ) {
 		Element el = doc.createElement("body");
 		doc.getElementsByTagName("html").item(0).appendChild(el);
 		ParserStacks.openElements.push(el);
 		Parser.currentMode = InsertionMode.in_body;
+		treeConstructor.processToken(token);
 	}
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/BeforeHTML.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/BeforeHTML.java
@@ -7,10 +7,11 @@ import com.html5parser.SimplestTreeParser.InsertionMode;
 import com.html5parser.SimplestTreeParser.Parser;
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class BeforeHTML {
 
-	public void process(Document doc, Token token) {
+	public void process(Document doc, Token token, TreeConstructor treeConstructor) {
 		switch (token.getType()) {
 
 		// A DOCTYPE token
@@ -34,22 +35,22 @@ public class BeforeHTML {
 			break;
 
 		case start_tag:
-			TokenStartTag(doc, token.getValue());
+			TokenStartTag(doc, token.getValue(), token,  treeConstructor);
 			break;
 
 		case end_tag:
-			TokenEndTag(doc, token.getValue());
+			TokenEndTag(doc, token.getValue(), token,  treeConstructor);
 			break;
 
 		// Anything else
 		case end_of_file:
 		default:
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token,  treeConstructor);
 			break;
 		}
 	}
 
-	private void TokenAnythingElse(Document doc) {
+	private void TokenAnythingElse(Document doc,Token token, TreeConstructor treeConstructor) {
 		// Create an html element. Append it to the Document object. Put this
 		// element in the stack of open elements.
 		// If the Document is being loaded as part of navigation of a browsing
@@ -62,9 +63,10 @@ public class BeforeHTML {
 		doc.appendChild(el);
 		ParserStacks.openElements.push(el);
 		Parser.currentMode = InsertionMode.before_head;
+		treeConstructor.processToken(token);
 	}
 
-	private void TokenStartTag(Document doc, String value) {
+	private void TokenStartTag(Document doc, String value,Token token, TreeConstructor treeConstructor) {
 		// A start tag whose tag name is "html"
 		// Create an element for the token in the HTML namespace. Append it to
 		// the Document object. Put this element in the stack of open elements.
@@ -80,12 +82,12 @@ public class BeforeHTML {
 		// must be passed the Document object.
 		// Switch the insertion mode to "before head".
 		if (value.equals("html")) 
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token,  treeConstructor);
 		else
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token,  treeConstructor);
 	}
 
-	private void TokenEndTag(Document doc, String value) {
+	private void TokenEndTag(Document doc, String value, Token token, TreeConstructor  treeConstructor) {
 		// An end tag whose tag name is one of: "head", "body", "html", "br"
 		// Act as described in the "anything else" entry below.
 		// Any other end tag
@@ -95,7 +97,7 @@ public class BeforeHTML {
 		case "body":
 		case "html":
 		case "br":
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token,  treeConstructor);
 			break;
 		default:
 			ParserStacks.parseErrors

--- a/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/BeforeHead.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/BeforeHead.java
@@ -7,10 +7,11 @@ import com.html5parser.SimplestTreeParser.InsertionMode;
 import com.html5parser.SimplestTreeParser.Parser;
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class BeforeHead {
 
-	public void process(Document doc, Token token) {
+	public void process(Document doc, Token token, TreeConstructor treeConstructor) {
 		switch (token.getType()) {
 		case character:
 			break;
@@ -27,15 +28,17 @@ public class BeforeHead {
 			break;
 		case end_of_file:
 		default:
-			TokenAnythingElse(doc);
+			TokenAnythingElse(doc, token, treeConstructor);
 			break;
 		}
 	}
 
-	private void TokenAnythingElse(Document doc) {
+	private void TokenAnythingElse(Document doc,Token token, TreeConstructor treeConstructor ) {
 		Element el = doc.createElement("head");
 		doc.getElementsByTagName("html").item(0).appendChild(el);
 		ParserStacks.openElements.push(el);
 		Parser.currentMode = InsertionMode.in_head;
+		treeConstructor.processToken(token);
+		
 	}
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/InHead.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/InHead.java
@@ -6,10 +6,11 @@ import com.html5parser.SimplestTreeParser.InsertionMode;
 import com.html5parser.SimplestTreeParser.Parser;
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class InHead {
 
-	public void process(Document doc, Token token) {
+	public void process(Document doc, Token token, TreeConstructor treeConstructor ) {
 		switch (token.getType()) {
 		case character:
 			break;
@@ -26,13 +27,14 @@ public class InHead {
 			break;
 		case end_of_file:
 		default:
-			TokenAnythingElse();
+			TokenAnythingElse( token,  treeConstructor );
 			break;
 		}
 	}
 
-	private void TokenAnythingElse() {
+	private void TokenAnythingElse(Token token, TreeConstructor treeConstructor ) {
 		ParserStacks.openElements.pop();
 		Parser.currentMode = InsertionMode.after_head;
+		treeConstructor.processToken(token);
 	}
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/Initial.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/InsertionModes/Initial.java
@@ -5,10 +5,11 @@ import org.w3c.dom.Document;
 import com.html5parser.SimplestTreeParser.InsertionMode;
 import com.html5parser.SimplestTreeParser.Parser;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class Initial {
 
-	public boolean process(Document doc, Token token) {
+	public boolean process(Document doc, Token token, TreeConstructor treeConstructor) {
 		switch (token.getType()) {
 			case DOCTYPE:
 				break;
@@ -31,13 +32,13 @@ public class Initial {
 			case start_tag:
 			case end_tag:
 			default:
-				TokenAnythingElse();
-				break;
+				TokenAnythingElse( token,  treeConstructor);
 		}
 		return false;
 	}
 
-	private void TokenAnythingElse() {
+	private void TokenAnythingElse(Token token, TreeConstructor treeConstructor) {
 		Parser.currentMode = InsertionMode.before_html;
+		treeConstructor.processToken(token);
 	}
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/Parser.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/Parser.java
@@ -18,8 +18,8 @@ import org.w3c.dom.Element;
 
 public class Parser {
 
-	public static InsertionMode currentMode = InsertionMode.initial;
-	public static TokenizerState currentState = TokenizerState.Data_state;
+	public static InsertionMode currentMode ;
+	public static TokenizerState currentState ;
 
 	public static void main(String[] args) {
 		System.out.println("Hello World!");
@@ -30,12 +30,12 @@ public class Parser {
 		new Parser().parse(new ByteArrayInputStream(input.getBytes()));
 	}
 
-	public void blabla(Document doc) {
-		Element el2 = doc.createElement("body");
-		doc.getElementsByTagName("html").item(0).appendChild(el2);
-	}
-
 	public Document parse(InputStream stream) {
+		
+		//Initialization
+		Parser.currentMode = InsertionMode.initial;
+		Parser.currentState = TokenizerState.Data_state;
+		
 		Document doc = null;
 		try {
 			stream = new Decoder().ValidateEncoding(stream);

--- a/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/Tokenizer.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/Tokenizer.java
@@ -12,7 +12,9 @@ import com.html5parser.TokenizerStates.Data_state;
 import com.html5parser.TokenizerStates.State;
 
 public class Tokenizer {
-
+	
+	private TokenizerContext context = new TokenizerContext();
+	
 	/**
 	 * Tokenize a stream.
 	 * 
@@ -23,24 +25,26 @@ public class Tokenizer {
 	 *             invalid stream codification error.
 	 */
 	public Document Tokenize(InputStream stream) {
-		TreeConstructor treeConstructor = new TreeConstructor();
-		Token currentToken = null;
+		TreeConstructor treeConstructor = context.getTreeConstructor();
+		State state = context.getState();
 		// BufferedReader in = new BufferedReader(new
 		// InputStreamReader(url.openStream(), "UTF-8"));
+	
 		BufferedReader in;
 		try {
 			in = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
-
-			State state = new Data_state();
+			
 			int currentChar = 0;
 			while ((currentChar = in.read()) != -1) {
-				currentToken = state.process(currentChar, treeConstructor, currentToken);
-				state = state.nextState();
+				context.setCurrentChar(currentChar);
+				state.process(context);
+				//state = state.nextState();
 			}
 
 			// EOF Procedure
 			// Send value -1 for EOF
-			state.process(-1, treeConstructor, null);
+			context.setCurrentChar(-1);
+			state.process(context);
 
 			// return treeConstructor
 			// .ProcessToken(new Token(TokenType.end_of_file, null));
@@ -83,7 +87,7 @@ public class Tokenizer {
 			e.printStackTrace();
 		}
 
-		return treeConstructor.ProcessToken(null);
+		return treeConstructor.getDocument();
 
 	}
 

--- a/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/TokenizerContext.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/TokenizerContext.java
@@ -1,0 +1,41 @@
+package com.html5parser.SimplestTreeParser;
+
+import com.html5parser.TokenizerStates.Data_state;
+import com.html5parser.TokenizerStates.State;
+
+public class TokenizerContext {
+
+	
+	private State state = new Data_state();
+	private TreeConstructor treeConstructor = new TreeConstructor();
+	private Token currentToken = null;
+	private int currentChar = 0;
+	
+	public State getState() {
+		return state;
+	}
+	public void setState(State state) {
+		this.state = state;
+	}
+	public TreeConstructor getTreeConstructor() {
+		return treeConstructor;
+	}
+	public void setTreeConstructor(TreeConstructor treeConstructor) {
+		this.treeConstructor = treeConstructor;
+	}
+	public Token getCurrentToken() {
+		return currentToken;
+	}
+	public void setCurrentToken(Token currentToken) {
+		this.currentToken = currentToken;
+	}
+	public int getCurrentChar() {
+		return currentChar;
+	}
+	public void setCurrentChar(int currentChar) {
+		this.currentChar = currentChar;
+	}
+	
+	
+	
+}

--- a/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/TreeConstructor.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/SimplestTreeParser/TreeConstructor.java
@@ -38,26 +38,24 @@ public class TreeConstructor {
 
 	public Document doc = null;
 
-	public Document ProcessToken(Token token) {
-		if (token == null)
-			return doc;
+	public void processToken(Token token) {
 		boolean stopParsing = false;
-		while (!stopParsing) {
+		//while (!stopParsing) {
 			switch (Parser.currentMode) {
 			case initial:
-				new Initial().process(doc, token);
+				new Initial().process(doc, token, this);
 				break;
 			case before_html:
-				new BeforeHTML().process(doc, token);
+				new BeforeHTML().process(doc, token, this);
 				break;
 			case before_head:
-				new BeforeHead().process(doc, token);
+				new BeforeHead().process(doc, token, this);
 				break;
 			case in_head:
-				new InHead().process(doc, token);
+				new InHead().process(doc, token, this);
 				break;
 			case after_head:
-				new AfterHead().process(doc, token);
+				new AfterHead().process(doc, token, this);
 				break;
 			case in_body:
 				stopParsing = new InBody().process(doc, token);
@@ -65,7 +63,10 @@ public class TreeConstructor {
 			default:
 				break;
 			}
-		}
+		//}		
+	}
+	
+	public Document getDocument(){
 		return doc;
 	}
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Data_state.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Data_state.java
@@ -3,13 +3,14 @@ package com.html5parser.TokenizerStates;
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
 import com.html5parser.SimplestTreeParser.Token.TokenType;
+import com.html5parser.SimplestTreeParser.TokenizerContext;
 import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class Data_state implements State {
 
-	private State nextState;
-
-	public Token process(int currentChar, TreeConstructor treeConstructor, Token currentToken) {
+	public void process(TokenizerContext context) {
+		int currentChar = context.getCurrentChar();
+		TreeConstructor treeConstructor = context.getTreeConstructor();
 		switch (currentChar) {
 		// U+0026 AMPERSAND (&)
 		// Switch to the character reference in data state.
@@ -17,17 +18,17 @@ public class Data_state implements State {
 			// nextState = new Character_reference_in_data_state();
 			break;
 
-		// U+0026 AMPERSAND (&)
+		// U+0026 AMPERSAND (<)
 		// Switch to the character reference in data state.
 		case 0x003C:
-			nextState = new Tag_open_state();
+			context.setState(new Tag_open_state());
 			break;
 
 		// U+0000 NULL
 		// Parse error. Emit the current input character as a character token.
 		case 0x0000:
 			ParserStacks.parseErrors.push("NULL Character encountered");
-			treeConstructor.ProcessToken(new Token(TokenType.character, String
+			treeConstructor.processToken(new Token(TokenType.character, String
 					.valueOf(currentChar)));
 			break;
 
@@ -35,23 +36,16 @@ public class Data_state implements State {
 		// Emit an end-of-file token.
 		case -1:
 			treeConstructor
-					.ProcessToken(new Token(TokenType.end_of_file, null));
+					.processToken(new Token(TokenType.end_of_file, null));
 			break;
 
 		// Anything else
 		// Emit the current input character as a character token.
 		default:
-			treeConstructor.ProcessToken(new Token(TokenType.character, String
+			treeConstructor.processToken(new Token(TokenType.character, String
 					.valueOf(currentChar)));
 			break;
 		}
-		
-		return currentToken;
-	}
-
-	public State nextState() {
-		// TODO Auto-generated method stub
-		return nextState;
 	}
 
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/State.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/State.java
@@ -1,12 +1,13 @@
 package com.html5parser.TokenizerStates;
 
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TokenizerContext;
 import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public interface State {
 
-	public Token process(int currentChar, TreeConstructor treeConstructor, Token currentToken);
+	public void process(TokenizerContext context);
 	
-	public State nextState();
+	//public State nextState();
 		
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Tag_name_state.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Tag_name_state.java
@@ -2,13 +2,15 @@ package com.html5parser.TokenizerStates;
 
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TokenizerContext;
 import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class Tag_name_state implements State {
 
-	private State nextState;
-
-	public Token process(int currentChar, TreeConstructor treeConstructor, Token currentToken) {
+	public void process(TokenizerContext context) {
+		int currentChar = context.getCurrentChar();
+		TreeConstructor treeConstructor = context.getTreeConstructor();
+		Token currentToken = context.getCurrentToken();
 
 		// U+0041 LATIN CAPITAL LETTER A through to U+005A LATIN CAPITAL LETTER
 		// Z
@@ -39,8 +41,8 @@ public class Tag_name_state implements State {
 		// U+003E GREATER-THAN SIGN (>)
 		// Switch to the data state. Emit the current tag token
 		case 0x003E: // >
-			nextState = new Data_state();
-			treeConstructor.ProcessToken(currentToken);
+			context.setState(new Data_state());
+			treeConstructor.processToken(currentToken);
 			break;
 
 		// U+0000 NULL
@@ -56,8 +58,8 @@ public class Tag_name_state implements State {
 		// Parse error. Switch to the data state. Reconsume the EOF character.
 		case -1:
 			ParserStacks.parseErrors.push("Invalid character - EOF");
-			nextState = new Data_state();
-			nextState.process(-1, treeConstructor, currentToken);
+			context.setState(new Data_state());
+			context.getState().process(context);
 			break;
 
 		// Anything else
@@ -66,16 +68,12 @@ public class Tag_name_state implements State {
 		default:
 			currentToken.setValue(currentToken.getValue().concat(
 					String.valueOf(Character.toChars(currentChar))));
-			nextState = new Tag_name_state();
+			context.setState(new Tag_name_state());
 			break;
 		}
 
-		return currentToken;
 		
 	}
 
-	public State nextState() {
-		return nextState;
-	}
 
 }

--- a/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Tag_open_state.java
+++ b/SimplestTreeParser/src/main/java/com/html5parser/TokenizerStates/Tag_open_state.java
@@ -2,14 +2,15 @@ package com.html5parser.TokenizerStates;
 
 import com.html5parser.SimplestTreeParser.ParserStacks;
 import com.html5parser.SimplestTreeParser.Token;
+import com.html5parser.SimplestTreeParser.TokenizerContext;
 import com.html5parser.SimplestTreeParser.Token.TokenType;
 import com.html5parser.SimplestTreeParser.TreeConstructor;
 
 public class Tag_open_state implements State {
 
-	private State nextState;
-	
-	public Token process(int currentChar, TreeConstructor treeConstructor, Token currentToken) {
+	public void process(TokenizerContext context) {
+		int currentChar = context.getCurrentChar();
+		TreeConstructor treeConstructor = context.getTreeConstructor();
 
 		// U+0041 LATIN CAPITAL LETTER A through to U+005A LATIN CAPITAL LETTER
 		// Z
@@ -27,9 +28,10 @@ public class Tag_open_state implements State {
 		// character, then switch to the tag name state. (Don't emit the token
 		// yet; further details will be filled in before it is emitted.)
 		if (currentChar > 96 && currentChar < 123) {
-			currentToken = new Token(TokenType.start_tag,
+			Token currentToken = new Token(TokenType.start_tag,
 					String.valueOf(Character.toChars(currentChar)));
-			nextState = new Tag_name_state();
+			context.setCurrentToken(currentToken);
+			context.setState(new Tag_name_state());
 		} else {
 			switch (currentChar) {
 			// "!" (U+0021)
@@ -56,17 +58,12 @@ public class Tag_open_state implements State {
 			// SIGN character token. Reconsume the current input character.
 			default:
 				ParserStacks.parseErrors.push("Invalid character");
-				nextState = new Data_state();
-				treeConstructor.ProcessToken(new Token(TokenType.character,
+				context.setState(new Data_state());
+				treeConstructor.processToken(new Token(TokenType.character,
 						String.valueOf(0x003C)));
 				break;
 			}
 		}
-		return currentToken;
-	}
-
-	public State nextState() {
-		return nextState;
 	}
 
 }

--- a/SimplestTreeParser/src/test/java/com/html5parser/SimplestTreeParser/ParserTest.java
+++ b/SimplestTreeParser/src/test/java/com/html5parser/SimplestTreeParser/ParserTest.java
@@ -1,0 +1,99 @@
+package com.html5parser.SimplestTreeParser;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+@RunWith(value = Parameterized.class)
+public class ParserTest {
+	
+	private Parser parser;
+	
+	private String input;
+ 
+	//parameters pass via this constructor
+	public ParserTest(String input) {
+		this.input = input;
+	}
+ 
+	//Declares parameters here
+	@Parameters(name = "Test {0}")
+	public static Iterable<Object[]> data1() {
+		return Arrays.asList(new Object[][] { 
+			{ ""}, 
+			{ "    " }, 
+			{ "<html>"},
+			{ "<head>"},
+			{ "<body>"},
+			
+			{ "<html/>"},
+			{ "<head/>"},
+			{ "<body/>"},
+			
+			{ "<html"},
+			{ "<html/"},
+			{ "<head/"},
+			{ "<body/"},
+			{ "<html/><xx"},
+			
+			{ "<html><head><body>"},
+			{ "<html><body>"},
+			{ "<head><body><html/>"},
+			
+			{ "<html>             "},
+			{ "<html>      <head><body><html/>"},
+			
+			{ "<html>//n<head/>//n<body/>//n</html>"},
+			
+		});
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		parser = new Parser();
+	}
+	
+	@Test
+	public final void tests() {
+		
+		Document doc = parser.parse(new ByteArrayInputStream((input).getBytes()));
+		
+		//Assert doc has only one child
+		assertTrue(doc.getChildNodes().getLength() == 1);
+		
+		//Assert this only child is the html tag
+		Node html = doc.getLastChild();
+		assertTrue("html tag incorrect "+ html.getNodeName(), html.getNodeName().equals("html"));
+		
+		//Assert doc has two children
+		assertTrue(html.getChildNodes().getLength() == 2);
+		
+		//Assert html has head and body as children
+		Node head = html.getFirstChild();
+		assertTrue("head tag incorrect: "+ head.getNodeName(), head.getNodeName().equals("head"));
+		
+		Node body = head.getNextSibling();
+		assertTrue("body tag incorrect "+ body.getNodeName(), body.getNodeName().equals("body"));
+		
+		//Assert head and body have no children
+		
+		assertTrue(head.getChildNodes().getLength() == 0);
+		assertTrue(body.getChildNodes().getLength() == 0);
+		
+	}
+
+	
+	
+
+
+
+}


### PR DESCRIPTION
Updated TreeConstructor getter of doc and the loop was removed. The doc is not returned anymore at the end of the treeConstructor, instead the
Parser get the doc through the getter.

Several fixes to the insertion modes and tokenizer states.

State pattern implemented in tokenizer using a Context class.

Junit version updated to the last version = 4.12
